### PR TITLE
refactor(): move intents to `molecule-input-container`

### DIFF
--- a/molecule-input-container.js
+++ b/molecule-input-container.js
@@ -1,104 +1,14 @@
-/** @jsx hJSX */
-
-import {hJSX} from '@cycle/dom'; // eslint-disable-line
 import cuid from 'cuid';
-import combineClassNames from '@cyclic/util-combine-class-names';
+import intent from './molecule-input-container/intent.js';
+import model from './molecule-input-container/model.js';
+import view from './molecule-input-container/view.js';
 
 const DIALOGUE_NAME = `molecule-InputContainer`;
 
-function model(props$) {
-  return props$;
-}
-
-function view({state$, id}) {
-  return state$.map((state) => {
-    const {
-      className,
-      label,
-      input,
-      isNoFloatingLabel,
-      isDisabled,
-      isFocused,
-      inputValue} = state;
-
-    const containerClassMod = isDisabled ? `isDisabled` : ``;
-
-    const hasInputContent = !!inputValue || inputValue === 0;
-
-    const isLabelFloating = !isNoFloatingLabel && hasInputContent;
-
-    const inputContentClassMods = [];
-
-    if (isLabelFloating) {
-      inputContentClassMods.push(`isFloatingLabel`);
-    }
-    if (isLabelFloating && isFocused) {
-      inputContentClassMods.push(`isHighlightedLabel`);
-    }
-    if (isNoFloatingLabel && hasInputContent) {
-      inputContentClassMods.push(`isHiddenLabel`);
-    }
-
-    const underlineClassMod = isFocused ? `isHighlighted` : ``;
-
-    return ( // eslint-disable-line
-      <div
-        className={combineClassNames(
-          id,
-          DIALOGUE_NAME,
-          className,
-          containerClassMod)}>
-
-        <div
-          className={combineClassNames(
-            `${DIALOGUE_NAME}_floatedLabelPlaceholder`,
-            `atom-Typography--caption`
-            )}>&nbsp;</div>
-
-        <div
-          className={combineClassNames(
-            `${DIALOGUE_NAME}_inputContent`,
-            inputContentClassMods,
-            `atom-FlexLayout--horizontal`,
-            `atom-FlexLayout--end`
-          )}>
-          <div
-            className={combineClassNames(
-              `${DIALOGUE_NAME}_labelAndInputContainer`,
-              `atom-FlexLayout_flex`,
-              `atom-Layout--relative`,
-              `atom-Typography--subhead`
-            )}>
-            {label}
-            {input}
-          </div>
-        </div>
-
-        <div
-          className={combineClassNames(
-            `${DIALOGUE_NAME}_underline`,
-            underlineClassMod
-          )}>
-          <div
-            className={combineClassNames(
-              `${DIALOGUE_NAME}_unfocusedLine`,
-              `atom-Layout--fit`
-            )}></div>
-          <div
-            className={combineClassNames(
-              `${DIALOGUE_NAME}_focusedLine`,
-              `atom-Layout--fit`
-            )}></div>
-        </div>
-
-      </div>
-    );
-  });
-}
-
-function moleculeInputContainer({props$}) {
+function moleculeInputContainer({DOM, props$}) {
   const id = cuid();
-  const state$ = model(props$);
+  const actions = intent({DOM, id});
+  const state$ = model({props$, actions});
 
   return {
     DOM: view({state$, id}),

--- a/molecule-input-container/intent.js
+++ b/molecule-input-container/intent.js
@@ -1,0 +1,21 @@
+import {Rx} from '@cycle/core';
+
+function intent({DOM, id}) {
+  const inputSelector = `.${id} INPUT`;
+  const textareaSelector = `.${id} TEXTAREA`;
+
+  return {
+    isFocused$: Rx.Observable.merge(
+      DOM.select(inputSelector).events(`focus`).map(() => true),
+      DOM.select(inputSelector).events(`blur`).map(() => false)
+    ).merge(
+      DOM.select(textareaSelector).events(`focus`).map(() => true),
+      DOM.select(textareaSelector).events(`blur`).map(() => false)
+    ).startWith(false),
+    value$: DOM.select(`.${id}`).events(`input`)
+      .map((e) => e.target.value)
+      .startWith(``),
+  };
+}
+
+export default intent;

--- a/molecule-input-container/model.js
+++ b/molecule-input-container/model.js
@@ -1,0 +1,14 @@
+function model({props$, actions}) {
+  return props$.combineLatest(
+    actions.isFocused$,
+    actions.value$,
+    (props, isFocused, value) => {
+      props.isFocused = isFocused;
+      props.value = value;
+
+      return props;
+    }
+  );
+}
+
+export default model;

--- a/molecule-input-container/view.js
+++ b/molecule-input-container/view.js
@@ -1,0 +1,93 @@
+/** @jsx hJSX */
+
+import {hJSX} from '@cycle/dom'; // eslint-disable-line
+import {DIALOGUE_NAME} from '../molecule-input-container.js';
+import combineClassNames from '@cyclic/util-combine-class-names';
+
+function renderFloatedLabelPlaceholder() {
+  return (// eslint-disable-line
+    <div className={combineClassNames(
+      `${DIALOGUE_NAME}_floatedLabelPlaceholder`,
+      `atom-Typography--caption`)}>&nbsp;</div>
+  );
+}
+
+function renderInputContent(state) {
+  const {
+    label,
+    input,
+    isNoFloatingLabel,
+    isFocused,
+    value} = state;
+
+  const hasInputContent = !!value || value === 0;
+
+  const isLabelFloating = !isNoFloatingLabel && hasInputContent;
+
+  const inputContentClassMods = [];
+
+  if (isLabelFloating) {
+    inputContentClassMods.push(`isFloatingLabel`);
+  }
+  if (isLabelFloating && isFocused) {
+    inputContentClassMods.push(`isHighlightedLabel`);
+  }
+  if (isNoFloatingLabel && hasInputContent) {
+    inputContentClassMods.push(`isHiddenLabel`);
+  }
+
+  return (// eslint-disable-line
+    <div
+      className={combineClassNames(
+        `${DIALOGUE_NAME}_inputContent`,
+        inputContentClassMods,
+        `atom-FlexLayout--horizontal`,
+        `atom-FlexLayout--end`)}>
+      <div
+        className={combineClassNames(
+          `${DIALOGUE_NAME}_labelAndInputContainer`,
+          `atom-FlexLayout_flex`,
+          `atom-Layout--relative`,
+          `atom-Typography--subhead`)}>
+        {label}
+        {input}
+      </div>
+    </div>
+  );
+}
+
+function renderUnderline(state) {
+  const underlineClassMod = state.isFocused ? `isHighlighted` : ``;
+
+  return (// eslint-disable-line
+    <div className={combineClassNames(
+      `${DIALOGUE_NAME}_underline`,
+      underlineClassMod)}>
+      <div className={combineClassNames(
+        `${DIALOGUE_NAME}_unfocusedLine`,
+        `atom-Layout--fit`)}></div>
+      <div className={combineClassNames(
+        `${DIALOGUE_NAME}_focusedLine`,
+        `atom-Layout--fit`)}></div>
+    </div>
+  );
+}
+
+function view({state$, id}) {
+  return state$.map((state) => {
+    const {className, isDisabled} = state;
+
+    const containerClassMod = isDisabled ? `isDisabled` : ``;
+
+    return ( // eslint-disable-line
+      <div className={combineClassNames(
+        id, DIALOGUE_NAME, className, containerClassMod)}>
+        {renderFloatedLabelPlaceholder()}
+        {renderInputContent(state)}
+        {renderUnderline(state)}
+      </div>
+    );
+  });
+}
+
+export default view;

--- a/molecule-input.js
+++ b/molecule-input.js
@@ -1,109 +1,11 @@
-/** @jsx hJSX */
-
-import {Rx} from '@cycle/core';
-import {hJSX} from '@cycle/dom'; // eslint-disable-line
 import cuid from 'cuid';
-import combineClassNames from '@cyclic/util-combine-class-names';
-import moleculeInputContainer from './molecule-input-container.js';
+import view from './molecule-input/view.js';
 
 const DIALOGUE_NAME = `molecule-Input`;
 
-function intent(DOM, id) {
-  const selector = `.${id} .${DIALOGUE_NAME}_input`;
-
-  return {
-    isFocused$: Rx.Observable.merge(
-      DOM.select(selector).events(`focus`).map(() => true),
-      DOM.select(selector).events(`blur`).map(() => false)
-    ).startWith(false),
-    value$: DOM.select(selector).events(`input`)
-      .map((e) => e.target.value)
-      .startWith(``),
-  };
-}
-
-function model(props$, actions) {
-  const {isFocused$, value$} = actions;
-
-  return props$.combineLatest(
-    isFocused$,
-    value$,
-    (props, isFocused, value) => {
-      const {className, label, type, isDisabled, isNoFloatingLabel} = props;
-
-      return {
-        className,
-        isFocused,
-        value,
-        label,
-        type,
-        isDisabled,
-        isNoFloatingLabel,
-      };
-    }
-  );
-}
-
-function view({state$, id}) {
-  const label$ = state$.map((state) => {
-    const {label} = state;
-
-    return (// eslint-disable-line
-      <label
-        className={`${DIALOGUE_NAME}_label`}
-        hidden={!label}>
-        {label}
-      </label>
-    );
-  });
-
-  const input$ = state$.map((state) => {
-    const {type, isDisabled} = state;
-
-    return (// eslint-disable-line
-      <input
-        className={`${DIALOGUE_NAME}_input`}
-        type={type}
-        disabled={isDisabled}/>
-    );
-  });
-
-  const inputContainer$ = state$.combineLatest(
-    label$,
-    input$,
-    (state, label, input) => {
-      const {isNoFloatingLabel, isDisabled, isFocused, value} = state;
-
-      const props$ = Rx.Observable.just({
-        label,
-        input,
-        isNoFloatingLabel,
-        isDisabled,
-        isFocused,
-        inputValue: value,
-      });
-
-      return moleculeInputContainer({props$});
-    }
-  );
-
-  return inputContainer$
-    .map((inputContainer) => inputContainer.DOM)
-    .combineLatest(state$, (inputContainerVTree, state) => {
-      return (// eslint-disable-line
-        <div
-          className={combineClassNames(id, DIALOGUE_NAME, state.className)}>
-          {inputContainerVTree}
-        </div>
-      );
-    }
-  );
-}
-
 function moleculeInput({DOM, props$}) {
   const id = cuid();
-  const actions = intent(DOM, id);
-  const state$ = model(props$, actions);
+  const state$ = props$;
 
   return {
     DOM: view({DOM, state$, id}),

--- a/molecule-input/view.js
+++ b/molecule-input/view.js
@@ -1,0 +1,48 @@
+/** @jsx hJSX */
+
+import {Rx} from '@cycle/core';
+import {hJSX} from '@cycle/dom'; // eslint-disable-line
+import {DIALOGUE_NAME} from '../molecule-input.js';
+import combineClassNames from '@cyclic/util-combine-class-names';
+import moleculeInputContainer from '../molecule-input-container.js';
+import renderLabel from '../shared/renderLabel.js';
+
+function renderInput(type, isDisabled) {
+  return (// eslint-disable-line
+    <input
+      className={`${DIALOGUE_NAME}_input`} type={type} disabled={isDisabled}/>
+  );
+}
+
+function makeInputContainer(DOM, state$) {
+  return state$.map(
+    (state) => {
+      const {label, type, isDisabled, isNoFloatingLabel} = state;
+
+      return moleculeInputContainer({
+        DOM, props$: Rx.Observable.just({
+          label: renderLabel(DIALOGUE_NAME, label),
+          input: renderInput(type, isDisabled),
+          isNoFloatingLabel,
+          isDisabled,
+        }),
+      });
+    }
+  );
+}
+
+function view({DOM, state$, id}) {
+  return makeInputContainer(DOM, state$)
+    .map((inputContainer) => inputContainer.DOM)
+    .combineLatest(state$, (inputContainerVTree, state) => {
+      return (// eslint-disable-line
+        <div
+          className={combineClassNames(id, DIALOGUE_NAME, state.className)}>
+          {inputContainerVTree}
+        </div>
+      );
+    }
+  );
+}
+
+export default view;

--- a/molecule-textarea.js
+++ b/molecule-textarea.js
@@ -1,108 +1,11 @@
-/** @jsx hJSX */
-
-import {Rx} from '@cycle/core';
-import {hJSX} from '@cycle/dom'; // eslint-disable-line
 import cuid from 'cuid';
-import combineClassNames from '@cyclic/util-combine-class-names';
-import moleculeInputContainer from './molecule-input-container.js';
-import atomAutogrowTextarea, {DIALOGUE_NAME as atomAutogrowTextareaName}
-  from '@cyclic/atom-autogrow-textarea';
+import view from './molecule-textarea/view.js';
 
 const DIALOGUE_NAME = `molecule-Textarea`;
 
-function intent({DOM, id}) {
-  const selector = `.${id} .${atomAutogrowTextareaName}`;
-
-  return {
-    isFocused$: Rx.Observable.merge(
-      DOM.select(selector).events(`focus`, true).map(() => true),
-      DOM.select(selector).events(`blur`, true).map(() => false)
-    ).startWith(false),
-    value$: DOM.select(selector).events(`input`)
-      .map(e => e.target.value)
-      .startWith(``),
-  };
-}
-
-function model({props$, actions}) {
-  const {isFocused$, value$} = actions;
-
-  return props$.combineLatest(
-    isFocused$,
-    value$,
-    (props, isFocused, value) => ({
-      className: props.className,
-      isFocused,
-      value,
-      label: props.label,
-      isNoFloatingLabel: props.isNoFloatingLabel,
-      isDisabled: props.isDisabled,
-    })
-  );
-}
-
-function view({DOM, state$, id}) {
-  const label$ = state$.map(
-    (state) => {
-      const {label} = state;
-
-      return (// eslint-disable-line
-        <label
-          className={`${DIALOGUE_NAME}_label`}
-          hidden={!label}>
-          {label}
-        </label>
-      );
-    }
-  );
-
-  const textarea$ = state$.map(
-    (state) => {
-      const spec = {
-        maxRows: state.maxRows,
-        rows: state.rows,
-      };
-      return atomAutogrowTextarea({DOM, props$: Rx.Observable.just(spec)});
-    }
-  );
-
-  const inputContainer$ = state$.combineLatest(
-    label$,
-    textarea$,
-    (state, label, textarea) => {
-      const {isFocused, value, isNoFloatingLabel, isDisabled} = state;
-
-      const props$ = textarea.DOM.map((input) => ({
-        label,
-        input,
-        isNoFloatingLabel,
-        isDisabled,
-        isFocused,
-        inputValue: value,
-      }));
-
-      return moleculeInputContainer({props$});
-    }
-  );
-
-  return inputContainer$
-    .map(inputContainer => inputContainer.DOM)
-    .combineLatest(state$, (inputContainerVTree, state) => {
-      return (// eslint-disable-line
-        <div
-          className={combineClassNames(id, DIALOGUE_NAME, state.className)}>
-          {inputContainerVTree}
-        </div>
-      );
-    }
-  );
-}
-
 function moleculeTextarea({DOM, props$}) {
   const id = cuid();
-
-  const actions = intent({DOM, id});
-  const state$ = model({props$, actions});
+  const state$ = props$;
 
   return {
     DOM: view({DOM, state$, id}),

--- a/molecule-textarea/view.js
+++ b/molecule-textarea/view.js
@@ -1,0 +1,43 @@
+/** @jsx hJSX */
+
+import {Rx} from '@cycle/core';
+import {hJSX} from '@cycle/dom'; // eslint-disable-line
+import {DIALOGUE_NAME} from '../molecule-textarea.js';
+import combineClassNames from '@cyclic/util-combine-class-names';
+import moleculeInputContainer from '../molecule-input-container.js';
+import atomAutogrowTextarea from '@cyclic/atom-autogrow-textarea';
+import renderLabel from '../shared/renderLabel.js';
+
+function makeInputContainer(DOM, state$) {
+  return state$.combineLatest(
+    atomAutogrowTextarea({DOM, props$: state$}).DOM,
+    (state, textareaVTree) => {
+      const {label, isNoFloatingLabel, isDisabled} = state;
+
+      return moleculeInputContainer({
+        DOM, props$: Rx.Observable.just({
+          label: renderLabel(DIALOGUE_NAME, label),
+          input: textareaVTree,
+          isNoFloatingLabel,
+          isDisabled,
+        }),
+      });
+    }
+  );
+}
+
+function view({DOM, state$, id}) {
+  return makeInputContainer(DOM, state$)
+    .map(inputContainer => inputContainer.DOM)
+    .combineLatest(state$, (inputContainerVTree, state) => {
+      return (// eslint-disable-line
+        <div
+          className={combineClassNames(id, DIALOGUE_NAME, state.className)}>
+          {inputContainerVTree}
+        </div>
+      );
+    }
+  );
+}
+
+export default view;

--- a/shared/renderLabel.js
+++ b/shared/renderLabel.js
@@ -1,0 +1,11 @@
+/** @jsx hJSX */
+
+import {hJSX} from '@cycle/dom'; // eslint-disable-line
+
+function renderLabel(dialogueName, label) {
+  return (// eslint-disable-line
+    <label className={`${dialogueName}_label`} hidden={!label}>{label}</label>
+  );
+}
+
+export default renderLabel;


### PR DESCRIPTION
Extract models, views and intents from all dialogues.
Centralize intent in `molecule-input-container`.

Closes #8
