### PR TITLE
perf(InputContainer): exclude `floatLabelPlaceholder` rendering

### DIFF
--- a/src/InputContainer/view.js
+++ b/src/InputContainer/view.js
@@ -4,13 +4,15 @@ import {hJSX} from '@cycle/dom'; // eslint-disable-line
 import combineClassNames from '@cyclic/util-combine-class-names';
 
 function renderFloatedLabelPlaceholder(state) {
-  const {componentName} = state;
+  const {componentName, disableLabelFloat} = state;
 
-  return (// eslint-disable-line
-    <div className={combineClassNames(
-      `${componentName}_floatedLabelPlaceholder`,
-      `atom-Typography--caption`)}>&nbsp;</div>
-  );
+  if (!disableLabelFloat) {
+    return (// eslint-disable-line
+      <div className={combineClassNames(
+        `${componentName}_floatedLabelPlaceholder`,
+        `atom-Typography--caption`)}>&nbsp;</div>
+    );
+  }
 }
 
 function renderInputContent(state, decoration) {


### PR DESCRIPTION
Add condition to render only when `disableLabelFloat` is `false`.

Closes #56
